### PR TITLE
Fixed imputation order handling in ImputationKernel

### DIFF
--- a/miceforest/imputation_kernel.py
+++ b/miceforest/imputation_kernel.py
@@ -183,9 +183,9 @@ class ImputationKernel(ImputedData):
                 if key in self.imputed_variables
             }
             self.imputation_order = list(
-                Series(_na_counts).sort_values(ascending=False).index
+                Series(_na_counts).sort_values(ascending=True).index
             )
-            if imputation_order == "decending":
+            if imputation_order == "descending":
                 self.imputation_order.reverse()
         elif imputation_order == "roman":
             self.imputation_order = self.imputed_variables.copy()


### PR DESCRIPTION
This pull request addresses a bug in the `ImputationKernel` class related to the `imputation_order` parameter. The issues fixed include:

- **Typo Correction**: `"decending"` was corrected to `"descending"`.
- **Sorting Configuration**: Updated sorting configuration for ascending order to use `ascending=True`.

### Steps to Reproduce

The following code can be used to test and verify the changes:

```python
import pandas as pd
import numpy as np
import miceforest as mf
from sklearn.datasets import load_iris

# Load the Iris dataset
iris_data = load_iris()
iris_df = pd.DataFrame(iris_data.data, columns=iris_data.feature_names)

# Introduce missing values
np.random.seed(42)
missing_indices = np.random.choice(iris_df.index, size=10, replace=False)
iris_df.loc[missing_indices, 'sepal length (cm)'] = np.nan
iris_df.loc[np.random.choice(iris_df.index, size=8, replace=False), 'sepal width (cm)'] = np.nan
iris_df.loc[np.random.choice(iris_df.index, size=4, replace=False), 'petal length (cm)'] = np.nan
iris_df.loc[np.random.choice(iris_df.index, size=2, replace=False), 'petal width (cm)'] = np.nan

# Initialize ImputationKernel with 'ascending' order
kernel_ascending = mf.ImputationKernel(iris_df, imputation_order='ascending')

# Initialize ImputationKernel with 'descending' order
kernel_descending = mf.ImputationKernel(iris_df, imputation_order='descending')

# Compare imputation orders
ascending_order = kernel_ascending.imputation_order
descending_order = kernel_descending.imputation_order

# Print equality comparison result
print("Are the imputation orders equal?")
print(ascending_order == descending_order)
```

### Related Issue

This PR resolves issue #90.
