### PR TITLE
pass a named argument to `lgbmodel._Booster__inner_predict`, required in ligthbgbm >= 4.7.0

### DIFF
--- a/miceforest/imputation_kernel.py
+++ b/miceforest/imputation_kernel.py
@@ -775,7 +775,7 @@ class ImputationKernel(ImputedData):
             )
             candidate_preds = candidate_preds.astype(_PRE_LINK_DATATYPE)  # type: ignore
         else:
-            candidate_preds = lgbmodel._Booster__inner_predict(0)  # type: ignore
+            candidate_preds = lgbmodel._Booster__inner_predict(data_idx=0) # type: ignore
             if logistic and not (shap or fast):
                 candidate_preds = logodds(candidate_preds).astype(_PRE_LINK_DATATYPE)
 


### PR DESCRIPTION
lightgbm 4.7.0 changed `Booster.__inner_predict()` from a positional argument to a keyword-only argument.

Fixes #104 